### PR TITLE
Add option to map the values of a prop with CSS-like syntax

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-export const _convertToObject = (text, ...vars) => props => {
+export const _convertToObject = (text = undefined, ...vars) => props => {
   const parsedTags = text.reduce((acc, item, i) => {
     let v = vars[i] || '';
 
@@ -21,26 +21,18 @@ export const _convertToObject = (text, ...vars) => props => {
   }, {});
 };
 
-export const styledMapFor = (enumName = undefined) => (...args) => props => {
-  let mapOfStyles;
-
-  if (Array.isArray(args[0])) {
-    // Are we using a tagged template literal?
-    mapOfStyles = _convertToObject(...args)(props);
-  } else {
-    // Regular object usage:
-    mapOfStyles = args[args.length - 1];
-  }
+const handleMapping = (enumName = undefined, isObject = undefined) => (...args) => props => {
+  // If we are using a tagged template literal, convert it to a object
+  const mapOfStyles = isObject
+    ? args[args.length - 1]
+    : _convertToObject(...args)(props);
 
   const styleKeys = Object.keys(mapOfStyles);
-  let val;
 
-  if (enumName) {
-    val = props[enumName];
-
-    if (mapOfStyles[val]) return mapOfStyles[val];
-  } else if (!enumName && typeof args[0] === 'string') {
-    val = props[args[0]];
+  // If the first argument is a string, styled-map works differently:
+  if (enumName !== undefined) {
+    // We use the value of a prop, rather than the key
+    const val = props[enumName];
 
     if (mapOfStyles[val]) return mapOfStyles[val];
   } else {
@@ -60,13 +52,29 @@ export const styledMapFor = (enumName = undefined) => (...args) => props => {
   return mapOfStyles[styleKeys.pop()];
 };
 
-const styledMap = (...args) => styledMapFor()(...args);
+const styledMap = (...args) => {
+  // If the function looks like: styledMap`styles`
+  if (Array.isArray(args[0])) {
+    return handleMapping(undefined, false)(...args);
+  }
+
+  if (typeof args[0] === 'string') {
+    // If the function looks like: styledMap(prop)`styles`
+    if (args.length === 1) return handleMapping(...args);
+
+    // If the function looks like: styledMap(prop, {styles})
+    return handleMapping(args[0], true)(...args);
+  }
+
+  // Otherwise the function looks like: styledMap({styles})
+  return handleMapping(undefined, true)(...args);
+};
 
 export const _dotProp = (string, object) => string
   .split('.')
   .reduce((acc, key) => acc[key], object);
 
-export const mapToTheme = (key) => 
+export const mapToTheme = (key) =>
   (props) => styledMap(_dotProp(key, props.theme));
 
 export default styledMap;

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ export const _convertToObject = (text, ...vars) => props => {
   }, {});
 };
 
-const styledMap = (...args) => (props) => {
+const styledMapFor = (enumName = undefined) => (...args) => props => {
   let mapOfStyles;
 
   if (Array.isArray(args[0])) {
@@ -33,12 +33,15 @@ const styledMap = (...args) => (props) => {
   }
 
   const styleKeys = Object.keys(mapOfStyles);
+  let val;
 
-  // If the first argument is a string, styled-map works differently:
-  if (typeof args[0] === 'string') {
-    // We use the value of a prop, rather than the key
-    const val = props[args[0]];
-    
+  if (enumName) {
+    val = props[enumName];
+
+    if (mapOfStyles[val]) return mapOfStyles[val];
+  } else if (!enumName && typeof args[0] === 'string') {
+    val = props[args[0]];
+
     if (mapOfStyles[val]) return mapOfStyles[val];
   } else {
     // Otherwise we do things the normal way:
@@ -57,6 +60,7 @@ const styledMap = (...args) => (props) => {
   return mapOfStyles[styleKeys.pop()];
 };
 
+const styledMap = (...args) => styledMapFor()(...args);
 
 export const _dotProp = (string, object) => string
   .split('.')

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ export const _convertToObject = (text, ...vars) => props => {
   }, {});
 };
 
-const styledMapFor = (enumName = undefined) => (...args) => props => {
+export const styledMapFor = (enumName = undefined) => (...args) => props => {
   let mapOfStyles;
 
   if (Array.isArray(args[0])) {

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -46,7 +46,6 @@ const stylesWithDefaultTTL = _convertToObject`
 
 describe('styledMap', () => {
   it('returns a function', () => {
-    const map = styledMap();
     expect(typeof styledMap()).toBe('function');
   });
 


### PR DESCRIPTION
I noticed that mapping to prop values can be done only by using objects, so I decided to adapt it to a CSS-like syntax by passing another argument to the `styledMap` function. It came out something like this:
```js
styledMap('variant')`
  large: 2rem;
  small: 1em;
`
```

However, this solution would be a breaking change because if I wanted to write a normal `styledMap` I'd have to do this:
```js
styledMap()`
  large: 2rem;
  small: 1em;
`
```

#### My Solution
I renamed the main function to `styledMapFor` that accepts the extra argument and `styledMap` simply calls this function with a default value.
This maps values from the prop 'variant':
```js
styledMapFor('variant')`
  large: 2rem;
  small: 1em;
`
```
This maps the props:
```js
styledMap`
  large: 2rem;
  small: 1em;
`
```

> Note: I'm not really sure if `styledMapFor` is the most appropriate name, if you have a better one write it.

#### What about using regular objects?
Objects can still be used but I think the library should stop supporting them.
```js
styledMap('variant', {
  primary: 'pink',
  secondary: 'red',
  info: 'blue',
  default: 'white',
})
```
```js
styledMap({
  primary: 'pink',
  secondary: 'red',
  info: 'blue',
  default: 'white',
})
```